### PR TITLE
Disable safety checks in Release mode

### DIFF
--- a/Assets/NativeQuadTree.cs
+++ b/Assets/NativeQuadTree.cs
@@ -32,9 +32,11 @@ namespace NativeQuadTree
 	public unsafe partial struct NativeQuadTree<T> : IDisposable where T : unmanaged
 	{
 		// Safety
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
 		AtomicSafetyHandle safetyHandle;
 		[NativeSetClassTypeToNullOnSchedule]
 		DisposeSentinel disposeSentinel;
+#endif
 
 		// Data
 		[NativeDisableUnsafePtrRestriction]


### PR DESCRIPTION
AtomicSafetyHandle and DisposeSentinel aren't available when doing a release build, this conditionally skips their declaration where before it just skipped their usage.